### PR TITLE
chore(lever): use assert macro

### DIFF
--- a/src/lever/contracts/lever.cairo
+++ b/src/lever/contracts/lever.cairo
@@ -109,13 +109,13 @@ pub mod lever {
         // 4. Borrow yin from caller's trove and mint to this contract
         fn up(ref self: ContractState, amount: Wad, lever_up_params: LeverUpParams) {
             let user: ContractAddress = get_caller_address();
-            assert(
+            assert!(
                 user == self
                     .abbot
                     .read()
                     .get_trove_owner(lever_up_params.trove_id)
                     .expect('Non-existent trove'),
-                'LEV: Not trove owner',
+                "LEV: Not trove owner",
             );
 
             let mut call_data: Array<felt252> = array![];
@@ -143,13 +143,13 @@ pub mod lever {
         // 5. Transfer remainder collateral asset to user
         fn down(ref self: ContractState, amount: Wad, lever_down_params: LeverDownParams) {
             let user: ContractAddress = get_caller_address();
-            assert(
+            assert!(
                 user == self
                     .abbot
                     .read()
                     .get_trove_owner(lever_down_params.trove_id)
                     .expect('Non-existent trove'),
-                'LEV: Not trove owner',
+                "LEV: Not trove owner",
             );
             let modify_lever_params = ModifyLeverParams {
                 user, action: ModifyLeverAction::LeverDown(lever_down_params),
@@ -259,7 +259,7 @@ pub mod lever {
     // Helper function to fetch the gate address for a yang, or otherwise throw.
     fn get_valid_gate(sentinel: ISentinelDispatcher, yang: ContractAddress) -> ContractAddress {
         let gate = sentinel.get_gate_address(yang);
-        assert(gate.is_non_zero(), 'LEV: Invalid yang');
+        assert!(gate.is_non_zero(), "LEV: Invalid yang");
         gate
     }
 }

--- a/src/lever/tests/test_lever.cairo
+++ b/src/lever/tests/test_lever.cairo
@@ -552,7 +552,7 @@ fn test_lever_up_unhealthy_fail() {
 
 #[test]
 #[fork("MAINNET_LEVER")]
-#[should_panic(expected: 'LEV: Not trove owner')]
+#[should_panic(expected: "LEV: Not trove owner")]
 fn test_unauthorized_lever_up_fail() {
     let lever: ILeverDispatcher = deploy_lever();
 
@@ -569,7 +569,7 @@ fn test_unauthorized_lever_up_fail() {
 
 #[test]
 #[fork("MAINNET_LEVER")]
-#[should_panic(expected: 'LEV: Invalid yang')]
+#[should_panic(expected: "LEV: Invalid yang")]
 fn test_lever_up_invalid_yang_fail() {
     let lever: ILeverDispatcher = deploy_lever();
 
@@ -591,7 +591,7 @@ fn test_lever_up_invalid_yang_fail() {
 
 #[test]
 #[fork("MAINNET_LEVER")]
-#[should_panic(expected: 'LEV: Not trove owner')]
+#[should_panic(expected: "LEV: Not trove owner")]
 fn test_unauthorized_lever_down_fail() {
     let lever: ILeverDispatcher = deploy_lever();
 
@@ -663,7 +663,7 @@ fn test_lever_down_insufficient_trove_yang_fail() {
 
 #[test]
 #[fork("MAINNET_LEVER")]
-#[should_panic(expected: 'LEV: Invalid yang')]
+#[should_panic(expected: "LEV: Invalid yang")]
 fn test_lever_down_invalid_yang_fail() {
     let lever: ILeverDispatcher = deploy_lever();
 


### PR DESCRIPTION
Standardize to `assert!` macro for better error messages in Lever module. The Stabilizer module already uses that macro.