### PR TITLE
feat(stabilizer): add early return if no yield

### DIFF
--- a/src/stabilizer/contracts/stabilizer.cairo
+++ b/src/stabilizer/contracts/stabilizer.cairo
@@ -320,6 +320,10 @@ pub mod stabilizer {
             mut yield_state: YieldState,
             amount: u256,
         ) {
+            if amount.is_zero() {
+                return;
+            }
+
             yield_state.yin_balance_snapshot -= amount;
             self.yield_state.write(yield_state);
 


### PR DESCRIPTION
This PR adds an optimization by adding an early return if there is no yield to be withdrawn, thereby also skipping the emission of `YieldStateUpdated` and `Claimed` events.