### PR TITLE
chore[stabilizer]: fix TVL calculation in data provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,4 @@ scarb test
 | Module | Address |
 | ------ | --------|
 | Stabilizer [CASH-USDC] | `0x03dbe818c99cf6658f23ef70656d64cce650fdb97105b96876d7e421fa25a528` |
-| Stabilizer Frontend Data Provider | `0x2e57ea04be4b8423ad91b9c6d49025167912ddec5f83c71a9656ef611f31aac` |
+| Stabilizer Frontend Data Provider | `0x0631dd1830b99223726b4e3d428ce8edb1d558922122ba2f496e96665d428fda` |

--- a/README.md
+++ b/README.md
@@ -25,4 +25,4 @@ scarb test
 | Module | Address |
 | ------ | --------|
 | Stabilizer [CASH-USDC] | `0x03dbe818c99cf6658f23ef70656d64cce650fdb97105b96876d7e421fa25a528` |
-| Stabilizer Frontend Data Provider | `0x0631dd1830b99223726b4e3d428ce8edb1d558922122ba2f496e96665d428fda` |
+| Stabilizer Frontend Data Provider | `0x062e44bdb480ec9e62ad1bdb2638c011c1c02840d9db349f7f048fc9286372a1` |

--- a/src/stabilizer/periphery/frontend_data_provider.cairo
+++ b/src/stabilizer/periphery/frontend_data_provider.cairo
@@ -34,7 +34,7 @@ pub trait IFrontendDataProvider<TContractState> {
 
 #[starknet::contract]
 pub mod stabilizer_fdp {
-    use core::num::traits::{WideMul, Zero};
+    use core::num::traits::{Pow, WideMul, Zero};
     use core::integer::{u512, u512_safe_div_rem_by_u256};
     use ekubo::interfaces::core::{ICoreDispatcher, ICoreDispatcherTrait};
     use ekubo::interfaces::mathlib::{IMathLibDispatcherTrait, dispatcher as mathlib};
@@ -152,14 +152,19 @@ pub mod stabilizer_fdp {
                 (pool_key.token0, pool_info.token0_amount, pool_info.token1_amount)
             };
 
+            let other_token_decimals: u8 = IERC20Dispatcher { contract_address: other_token }
+                .decimals();
             let other_token_price: Wad = convert_ekubo_oracle_price_to_wad(
                 IOracleDispatcher { contract_address: mainnet::ekubo_oracle() }
                     .get_price_x128_over_last(other_token, mainnet::shrine(), TWAP_PERIOD),
-                IERC20Dispatcher { contract_address: other_token }.decimals(),
+                other_token_decimals,
                 WAD_DECIMALS,
             );
 
-            other_token_amount.try_into().unwrap() * other_token_price
+            // Scale the other token to Wad precision
+            let scaled_other_token_amount: u256 = other_token_amount
+                * 10_u256.pow((WAD_DECIMALS - other_token_decimals).into());
+            scaled_other_token_amount.try_into().unwrap() * other_token_price
                 + yin_amount.try_into().unwrap()
         }
     }

--- a/src/stabilizer/tests/test_stabilizer.cairo
+++ b/src/stabilizer/tests/test_stabilizer.cairo
@@ -12,7 +12,9 @@ use opus_compose::stabilizer::constants::{BOUNDS, LOWER_TICK_MAG, UPPER_TICK_MAG
 use opus_compose::stabilizer::contracts::stabilizer::stabilizer as stabilizer_contract;
 use opus_compose::stabilizer::interfaces::stabilizer::IStabilizerDispatcherTrait;
 use opus_compose::stabilizer::math::get_cumulative_delta;
-use opus_compose::stabilizer::periphery::frontend_data_provider::IFrontendDataProviderDispatcherTrait;
+use opus_compose::stabilizer::periphery::frontend_data_provider::{
+    IFrontendDataProviderDispatcher, IFrontendDataProviderDispatcherTrait,
+};
 use opus_compose::stabilizer::types::{Stake, YieldState};
 use opus_compose::stabilizer::tests::utils::stabilizer_utils::{
     create_surplus, create_ekubo_position, create_valid_ekubo_position, fund_three_users, setup,
@@ -655,19 +657,6 @@ fn test_multi_users() {
             .into(),
         "token1 sanity check",
     );
-
-    let tvl = fdp.get_staked_tvl(stabilizer.contract_address);
-    let expected_tvl: Wad = (user1_yin_amt + user2_yin_amt + user3_yin_amt).try_into().unwrap();
-    let error_margin: Wad = 1000000000_u128.into(); // 10 ** 9
-    assert_equalish(tvl, expected_tvl, error_margin, 'wrong fdp tvl');
-
-    let user1_tvl = fdp.get_user_staked_tvl(stabilizer.contract_address, user1);
-    let expected_user1_tvl: Wad = user1_yin_amt.try_into().unwrap();
-    assert_equalish(user1_tvl, expected_user1_tvl, error_margin, 'wrong user 1 tvl');
-
-    let user2_tvl = fdp.get_user_staked_tvl(stabilizer.contract_address, user2);
-    let expected_user2_tvl: Wad = user2_yin_amt.try_into().unwrap();
-    assert_equalish(user2_tvl, expected_user2_tvl, error_margin, 'wrong user 2 tvl');
 
     let total_liquidity = stabilizer.get_total_liquidity();
     assert_eq!(total_liquidity, expected_total_liquidity, "Wrong total liquidity #1");


### PR DESCRIPTION
This PR fixes an issue with TVL calculation by scaling the other token amount to Wad precision.