### PR TITLE
chore: bump Cairo version

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-scarb 2.13.1
-starknet-foundry 0.55.0
+scarb 2.18.0
+starknet-foundry 0.60.0

--- a/Scarb.lock
+++ b/Scarb.lock
@@ -34,15 +34,15 @@ dependencies = [
 
 [[package]]
 name = "snforge_scarb_plugin"
-version = "0.55.0"
+version = "0.60.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:638535780a23d1491c2438e64045c479d16de6a69e41ad17ac065272c485873b"
+checksum = "sha256:924358bf316e502923f6733b50e239ea37585a05dc24c5fc8dd9e45f88cf7339"
 
 [[package]]
 name = "snforge_std"
-version = "0.55.0"
+version = "0.60.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:a04b0bf731f02307506dad368713099e701565edd9b98b044ca54b932c29ef74"
+checksum = "sha256:32e6baabec4f9af21089bc7ca685ffea5e4164497340ecbdb99314e568029195"
 dependencies = [
  "snforge_scarb_plugin",
 ]

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -6,15 +6,15 @@ edition = "2024_07"
 # See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
 
 [dependencies]
-starknet = ">= 2.13.1"
+starknet = ">= 2.18.0"
 ekubo = { git = "https://github.com/EkuboProtocol/starknet-contracts", rev = "cf2e95fd124bfb19491e1a7da9ffba4b63cc6c4e" }
 opus = ">= 1.3.0"
 access_control = ">= 0.5.0"
 wadray = ">= 0.6.1"
 
 [dev-dependencies]
-snforge_std = ">= 0.53.0"
-assert_macros = ">= 2.13.1"
+snforge_std = ">= 0.60.0"
+assert_macros = ">= 2.18.0"
 
 [lib]
 

--- a/src/lever/tests/test_lever.cairo
+++ b/src/lever/tests/test_lever.cairo
@@ -25,7 +25,7 @@ use snforge_std::{
     cheat_caller_address, declare, spy_events, start_cheat_caller_address,
     stop_cheat_caller_address,
 };
-use starknet::ContractAddress;
+use starknet::{ContractAddress, SyscallResultTrait};
 use wadray::{RAY_ONE, Ray, WAD_ONE, Wad};
 
 //
@@ -33,7 +33,7 @@ use wadray::{RAY_ONE, Ray, WAD_ONE, Wad};
 //
 
 fn deploy_lever() -> ILeverDispatcher {
-    let lever_class = declare("lever").unwrap().contract_class();
+    let lever_class = declare("lever").unwrap_syscall().contract_class();
 
     let calldata: Array<felt252> = array![
         mainnet::SHRINE.into(),
@@ -43,7 +43,7 @@ fn deploy_lever() -> ILeverDispatcher {
         mainnet::EKUBO_ROUTER.into(),
     ];
 
-    let (lever_addr, _) = lever_class.deploy(@calldata).unwrap();
+    let (lever_addr, _) = lever_class.deploy(@calldata).unwrap_syscall();
 
     start_cheat_caller_address(mainnet::SHRINE, mainnet::MULTISIG);
     IAccessControlDispatcher { contract_address: mainnet::SHRINE }
@@ -59,13 +59,13 @@ fn deploy_lever() -> ILeverDispatcher {
 }
 
 fn deploy_malicious_lever(lever: ContractAddress) -> IMaliciousLeverDispatcher {
-    let malicious_lever_class = declare("malicious_lever").unwrap().contract_class();
+    let malicious_lever_class = declare("malicious_lever").unwrap_syscall().contract_class();
 
     let calldata: Array<felt252> = array![
         mainnet::SHRINE.into(), mainnet::FLASH_MINT.into(), lever.into(),
     ];
 
-    let (malicious_lever_addr, _) = malicious_lever_class.deploy(@calldata).unwrap();
+    let (malicious_lever_addr, _) = malicious_lever_class.deploy(@calldata).unwrap_syscall();
 
     IMaliciousLeverDispatcher { contract_address: malicious_lever_addr }
 }
@@ -726,7 +726,7 @@ fn test_lever_down_exceeds_max_ltv_fail() {
 
     // Remove the first swap, so total amount swapped is 790.75 CASH worth of ETH
     let mut modified_swaps = lever_down_swaps();
-    modified_swaps.pop_front();
+    let _ = modified_swaps.pop_front();
 
     let debt_to_repay: u128 = 790750000000000000000;
 

--- a/src/stabilizer/contracts/stabilizer.cairo
+++ b/src/stabilizer/contracts/stabilizer.cairo
@@ -170,9 +170,7 @@ pub mod stabilizer {
             let position: GetTokenInfoResult = self
                 .ekubo_positions
                 .read()
-                .get_token_info(
-                    token_id.into(), self.pool_key.read().into(), self.bounds.read().into(),
-                );
+                .get_token_info(token_id, self.pool_key.read().into(), self.bounds.read().into());
             assert!(position.liquidity.is_non_zero(), "STB: No liquidity found");
 
             // Get updated yield state based on total liquidity before adding this position's

--- a/src/stabilizer/tests/test_estimator.cairo
+++ b/src/stabilizer/tests/test_estimator.cairo
@@ -15,7 +15,7 @@ use opus_compose::stabilizer::periphery::estimator::{
     IEstimatorDispatcher, IEstimatorDispatcherTrait,
 };
 use snforge_std::{CheatSpan, ContractClassTrait, DeclareResultTrait, cheat_caller_address, declare};
-use starknet::ContractAddress;
+use starknet::{ContractAddress, SyscallResultTrait};
 use wadray::WAD_ONE;
 
 const MAX_ITERATIONS: u8 = 20;
@@ -30,9 +30,9 @@ const USDC_INPUT_AMT: u128 = INPUT_AMT * USDC_SCALE;
 //
 
 fn deploy_estimator() -> IEstimatorDispatcher {
-    let estimator_class = declare("estimator").unwrap().contract_class();
+    let estimator_class = declare("estimator").unwrap_syscall().contract_class();
     let calldata: Array<felt252> = array![mainnet::EKUBO_CORE.into()];
-    let (estimator_addr, _) = estimator_class.deploy(@calldata).unwrap();
+    let (estimator_addr, _) = estimator_class.deploy(@calldata).unwrap_syscall();
 
     IEstimatorDispatcher { contract_address: estimator_addr }
 }

--- a/src/stabilizer/tests/utils.cairo
+++ b/src/stabilizer/tests/utils.cairo
@@ -20,7 +20,7 @@ pub mod stabilizer_utils {
         CheatSpan, ContractClass, ContractClassTrait, DeclareResultTrait, cheat_caller_address,
         declare, start_cheat_caller_address, stop_cheat_caller_address,
     };
-    use starknet::ContractAddress;
+    use starknet::{ContractAddress, SyscallResultTrait};
     use wadray::{RAY_ONE, Wad};
 
     pub const USDC_DECIMALS_DIFF_SCALE: u256 = 1000000000000; // 10 ** 12
@@ -36,10 +36,8 @@ pub mod stabilizer_utils {
     //
 
     pub fn setup(stabilizer_class: Option<ContractClass>) -> StabilizerTestConfig {
-        let stabilizer_class = match stabilizer_class {
-            Option::Some(class) => class,
-            Option::None => *(declare("stabilizer").unwrap().contract_class()),
-        };
+        let stabilizer_class = stabilizer_class
+            .unwrap_or_else(|| *declare("stabilizer").unwrap_syscall().contract_class());
 
         let mut calldata: Array<felt252> = array![
             mainnet::SHRINE.into(),
@@ -49,7 +47,7 @@ pub mod stabilizer_utils {
         ];
         POOL_KEY().serialize(ref calldata);
         BOUNDS().serialize(ref calldata);
-        let (stabilizer_addr, _) = stabilizer_class.deploy(@calldata).unwrap();
+        let (stabilizer_addr, _) = stabilizer_class.deploy(@calldata).unwrap_syscall();
 
         // Clear out surplus
         let equalizer = IEqualizerDispatcher { contract_address: mainnet::EQUALIZER };
@@ -68,8 +66,8 @@ pub mod stabilizer_utils {
             .grant_role(adjust_budget_role, mainnet::MULTISIG);
         stop_cheat_caller_address(mainnet::SHRINE);
 
-        let fdp_class = declare("stabilizer_fdp").unwrap().contract_class();
-        let (fdp_addr, _) = fdp_class.deploy(@array![]).unwrap();
+        let fdp_class = declare("stabilizer_fdp").unwrap_syscall().contract_class();
+        let (fdp_addr, _) = fdp_class.deploy(@array![]).unwrap_syscall();
 
         StabilizerTestConfig {
             stabilizer: IStabilizerDispatcher { contract_address: stabilizer_addr },


### PR DESCRIPTION
This PR bumps Cairo to 2.18.0 and Starknet Foundry to 0.60.0.